### PR TITLE
Change hyakkiyagyo origin to same site

### DIFF
--- a/assets/js/hyakkiyagyo.js
+++ b/assets/js/hyakkiyagyo.js
@@ -1,7 +1,7 @@
 export const setupHyakkiyagyo = () => {
 	const $hyakkiyagyo = document.querySelector("#hyakkiyagyo")
 	if (!$hyakkiyagyo) return;
-	const hyakkiyagyoOrigin = "https://sysad.trap.show"
+	const hyakkiyagyoOrigin = "https://hyakkiyagyo.trap.jp"
 
 	// adjust iframe size
 	window.addEventListener("message", (event) => {

--- a/post.hbs
+++ b/post.hbs
@@ -122,9 +122,9 @@
 {{^is "page"}}
 	{{!-- 下書きのプレビューのときはダミーのものを表示する --}}
 	{{#if post.published_at}}
-		<iframe id="hyakkiyagyo" class="lozad" data-src="https://sysad.trap.show/hyakkiyagyo/page/{{post.slug}}/" scrolling="no"></iframe>
+		<iframe id="hyakkiyagyo" class="lozad" data-src="https://hyakkiyagyo.trap.jp/page/{{post.slug}}/" scrolling="no"></iframe>
 	{{else}}
-		<iframe id="hyakkiyagyo" class="lozad" data-src="https://sysad.trap.show/hyakkiyagyo/" scrolling="no"></iframe>
+		<iframe id="hyakkiyagyo" class="lozad" data-src="https://hyakkiyagyo.trap.jp/" scrolling="no"></iframe>
 	{{/if}}
 	{{#if post.tags}}
 		{{#get "posts" filter="tags:[{{post.tags}}]+id:-{{post.id}}" include="tags,authors" limit="6"}}


### PR DESCRIPTION
ログイン機能を復活させるため

https://git.trap.jp/SysAd/dns/pulls/25 の適用後にマージ、NeoShowcaseで `hyakkiyagyo.trap.jp` でサーブするようにして、https://github.com/traPtitech/Ghost のsubomduleを書き換えてリリース、デプロイする