### PR TITLE
カーニングをpwidからpknaに変更

### DIFF
--- a/assets/css/critical/page.scss
+++ b/assets/css/critical/page.scss
@@ -4,7 +4,7 @@
 
 html {
 	font-family: "游ゴシック体", "YuGothic", "游ゴシック", "Yu Gothic", 'Hiragino Kaku Gothic ProN','ヒラギノ角ゴ ProN W3', sans-serif;
-	font-feature-settings: "pwid" 1;
+	font-feature-settings: "pkna" 1;
 	font-weight: 500;
 	word-break: break-all;
 	background: repeating-linear-gradient(


### PR DESCRIPTION
過剰に詰められるので個人的には`letter-spacing: 0.05em;`あたりを入れたいんですが、好みの問題すぎるので一旦pknaへの変更のみ行っています（それでもpkidよりもスカスカにはなるはずです）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **スタイル**
  * フォント表示設定を更新しました。OpenTypeフォント機能の設定が変更され、より適切なフォント表示が実現されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->